### PR TITLE
Alpha tween now affects itself and all its children.

### DIFF
--- a/Assets/Plugins/LeanTween.cs
+++ b/Assets/Plugins/LeanTween.cs
@@ -1723,8 +1723,18 @@ public static void update() {
 								SpriteRenderer ren = trans.gameObject.GetComponent<SpriteRenderer>();
 								if(ren!=null){
 									tween.from.x = ren.color.a;
-								}else if(trans.gameObject.renderer!=null){
-									tween.from.x = trans.gameObject.renderer.material.color.a;
+								}
+								else{
+									TextMesh tm = trans.gameObject.GetComponent<TextMesh>();
+									if (tm != null) {
+										tween.from.x = tm.color.a;
+									}
+									else if(trans.gameObject.renderer!=null){
+										tween.from.x = trans.gameObject.renderer.material.color.a;
+									}
+									else{
+										tween.from.x = 1f;
+									}
 								}
 								break;
 							#endif
@@ -1811,12 +1821,21 @@ public static void update() {
 									tween.from = new Vector3(0.0f, ren2.color.a, 0.0f);
 									tween.diff = new Vector3(1.0f,0.0f,0.0f);
 									tween.axis = new Vector3( ren2.color.r, ren2.color.g, ren2.color.b );
-								}else if(trans.gameObject.renderer!=null){
-									if(trans.gameObject.renderer){
-										Color col = trans.gameObject.renderer.material.color;
-										tween.from = new Vector3(0.0f, col.a, 0.0f);
+								}
+								else {
+									TextMesh tm2 = trans.gameObject.GetComponent<TextMesh>();
+									if (tm2 != null) {
+										tween.from = new Vector3(0.0f, tm2.color.a, 0.0f);
 										tween.diff = new Vector3(1.0f,0.0f,0.0f);
-										tween.axis = new Vector3( col.r, col.g, col.b );
+										tween.axis = new Vector3( tm2.color.r, tm2.color.g, tm2.color.b );
+									}
+									else if(trans.gameObject.renderer!=null){
+										if(trans.gameObject.renderer){
+											Color col = trans.gameObject.renderer.material.color;
+											tween.from = new Vector3(0.0f, col.a, 0.0f);
+											tween.diff = new Vector3(1.0f,0.0f,0.0f);
+											tween.axis = new Vector3( col.r, col.g, col.b );
+										}
 									}
 								}
 							#endif
@@ -2076,24 +2095,25 @@ public static void update() {
 
 							#else
 
-							SpriteRenderer ren = trans.gameObject.GetComponent<SpriteRenderer>();
-							if(ren!=null){
-								ren.color = new Color( ren.color.r, ren.color.g, ren.color.b, val);
-							}else{
-								if(trans.gameObject.renderer!=null){
-									foreach(Material mat in trans.gameObject.renderer.materials){
-		        						mat.color = new Color( mat.color.r, mat.color.g, mat.color.b, val);
-		    						}
-		    					}
-	    						if(trans.childCount>0){
-	    							foreach (Transform child in trans) {
-	    								if(child.gameObject.renderer!=null){
-		    								foreach(Material mat in child.gameObject.renderer.materials){
-				        						mat.color = new Color( mat.color.r, mat.color.g, mat.color.b, val);
-				    						}
-				    					}
+							// Applies to all itself and all children of any level
+							Transform[] children = trans.GetComponentsInChildren<Transform>();
+							foreach (Transform t in children)
+							{
+								SpriteRenderer ren = t.gameObject.GetComponent<SpriteRenderer>();
+								if(ren!=null){
+									ren.color = new Color( ren.color.r, ren.color.g, ren.color.b, val);
+								}
+								else {
+									TextMesh tm = t.gameObject.GetComponent<TextMesh>();
+									if (tm != null) {
+										tm.color = new Color( tm.color.r, tm.color.g, tm.color.b, val);
 									}
-	    						}
+									else if(t.gameObject.renderer!=null){
+										foreach(Material mat in t.gameObject.renderer.materials){
+											mat.color = new Color( mat.color.r, mat.color.g, mat.color.b, val);
+										}
+									}
+								}
 							}
 
     						#endif


### PR DESCRIPTION
Hi Russell, it's Leong here. I emailed you sometime ago with a short message thanking you for the LeanTween plugin. I came across something that I needed to fix, and I thought you'd like to add this fix to the master branch. I made it so that the "alpha" method now tweens the alpha for itself and all its children (including nested children), and also fixed the fact that TextMeshes do not have alpha tweening. I didn't fix the "color" method since I didn't need it, but it would've been similar. Hope it helps. Let me know if I did something wrong (e.g. inefficient coding), I'm still learning. :)
