### PR TITLE
Check finished tween id before delete it

### DIFF
--- a/Assets/Plugins/LeanTween/LeanTween.cs
+++ b/Assets/Plugins/LeanTween/LeanTween.cs
@@ -235,6 +235,7 @@ public class LeanTween : MonoBehaviour {
 
 	private static LTDescr[] tweens;
 	private static int[] tweensFinished;
+	private static int[] tweensFinishedIds;
 	private static LTDescr tween;
 	private static int tweenMaxSearch = -1;
 	private static int maxTweens = 400;
@@ -306,6 +307,7 @@ public class LeanTween : MonoBehaviour {
 			maxTweens = maxSimultaneousTweens;
 			tweens = new LTDescr[maxTweens];
 			tweensFinished = new int[maxTweens];
+			tweensFinishedIds = new int[maxTweens];
 			_tweenEmpty = new GameObject();
 			_tweenEmpty.name = "~LeanTween";
 			_tweenEmpty.AddComponent(typeof(LeanTween));
@@ -393,6 +395,7 @@ public class LeanTween : MonoBehaviour {
 
 					if (tween.updateInternal()) { // returns true if the tween is finished with it's loop
 						tweensFinished[finishedCnt] = i;
+						tweensFinishedIds[finishedCnt] = tweens[i].id;
 						finishedCnt++;
 					}
 				}
@@ -405,10 +408,13 @@ public class LeanTween : MonoBehaviour {
 			for(int i = 0; i < finishedCnt; i++){
 				j = tweensFinished[i];
 				tween = tweens[ j ];
-				//				Debug.Log("removing tween:"+tween);
-				removeTween(j);
-				if(tween.hasExtraOnCompletes && tween.trans!=null)
-					tween.callOnCompletes();
+
+				if (tween.id == tweensFinishedIds[i]){
+					//				Debug.Log("removing tween:"+tween);
+					removeTween(j);
+					if(tween.hasExtraOnCompletes && tween.trans!=null)
+						tween.callOnCompletes();
+				}
 			}
 
 		}


### PR DESCRIPTION
This commit fixes this issue:

**Steps to reproduce the issue:**
- Create Tween A (it's added to tweens array with index = 0)
- Create Tween B (it's added to tweens array with index = 1) with the same duration as A
- In Tween A onComplete event:
    * Cancel Tween B
    * Create Tween C (it's added to tweens array with index = 0)
    * Create Tween D (it's added to tweens array with index = 1)

I know it's a rare case, but as I'm using tweens in a lot of objects, I have found this situation.

**What happens?**
Tween D is cancelled immediately after it has been created.

**Why?**
In the frame when Tween A and Tween B finish, LeanTween's update method adds 0 and 1 to tweensFinished array. Then, it iterates over tweensFinished array deleting each tween, and executing its onComplete method. So, in the first iteration, Tween A is deleted, and then, Tween A onComplete method is executed, where we cancel Tween B. So, now, Tween A and B are both canceled. There are no active tweens, so, we create Tween C, and Tween D, adding them to tweens array with index 0 and 1. 
Now, the next iteration is executed (we are going to cancel tweensFinished[1]). But the tween at tweensFinished[1] is not the same tween it was when it as added to tweensFinished, and we are cancelling Tween D unintentionally.

**The fix**
I think an easy way to fix it is to check the tween id before cancel it, so we are sure we are deleting the tween we wanted.