### PR TITLE
Fixed a bug with canceling an old sequence causing a new unrelated sequence to get canceled

### DIFF
--- a/Assets/LeanTween/Framework/LeanTween.cs
+++ b/Assets/LeanTween/Framework/LeanTween.cs
@@ -627,17 +627,19 @@ public class LeanTween : MonoBehaviour {
             if (backId > tweens.Length - 1) { // sequence
                 int sequenceId = backId - tweens.Length;
                 LTSeq seq = sequences[sequenceId];
-                // Debug.Log("sequenceId:" + sequenceId+" maxSequences:"+maxSequences+" prev:"+seq.previous);
+                if (seq.counter == backCounter) {
+                    // Debug.Log("sequenceId:" + sequenceId+" maxSequences:"+maxSequences+" prev:"+seq.previous);
 
-                for (int i = 0; i < maxSequences; i++) {
-                    if (seq.current.tween != null) {
-                        int tweenId = seq.current.tween.uniqueId;
-                        int tweenIndex = tweenId & 0xFFFF;
-                        removeTween(tweenIndex);
+                    for (int i = 0; i < maxSequences; i++) {
+                        if (seq.current.tween != null) {
+                            int tweenId = seq.current.tween.uniqueId;
+                            int tweenIndex = tweenId & 0xFFFF;
+                            removeTween(tweenIndex);
+                        }
+                        if (seq.current.previous == null)
+                            break;
+                        seq.current = seq.current.previous;
                     }
-                    if (seq.current.previous == null)
-                        break;
-                    seq.current = seq.current.previous;
                 }
             } else { // tween
                 // Debug.Log("uniqueId:"+uniqueId+ " id:"+backId +" action:"+(TweenAction)backType + " tweens[id].type:"+tweens[backId].type);


### PR DESCRIPTION
- Check that the sequence counter matches the requested counter before canceling the tweens in the sequence. To reproduce the original behavior, save the uniqueId of a finished sequence, start a new sequence (it should occupy the same slot), and then attempt to cancel the original uniqueId. The new sequence will get canceled before it has a chance to do anything.