### PR TITLE
Explicitly reset static fields to make Unity's Domain Reload optional

### DIFF
--- a/Assets/LeanTween/Framework/LeanTween.cs
+++ b/Assets/LeanTween/Framework/LeanTween.cs
@@ -295,7 +295,7 @@ public class LeanTween : MonoBehaviour {
         dtEstimated = -1f;
         dtManual = 0;
 #if UNITY_3_5 || UNITY_4_0 || UNITY_4_0_1 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_5
-        float previousRealTime = 0;
+        previousRealTime = 0;
 #endif
         dtActual = 0;
         global_counter = 0;

--- a/Assets/LeanTween/Framework/LeanTween.cs
+++ b/Assets/LeanTween/Framework/LeanTween.cs
@@ -271,6 +271,41 @@ public class LeanTween : MonoBehaviour {
     public static AnimationCurve punch = new AnimationCurve( new Keyframe(0.0f, 0.0f ), new Keyframe(0.112586f, 0.9976035f ), new Keyframe(0.3120486f, -0.1720615f ), new Keyframe(0.4316337f, 0.07030682f ), new Keyframe(0.5524869f, -0.03141804f ), new Keyframe(0.6549395f, 0.003909959f ), new Keyframe(0.770987f, -0.009817753f ), new Keyframe(0.8838775f, 0.001939224f ), new Keyframe(1.0f, 0.0f ) );
     public static AnimationCurve shake = new AnimationCurve( new Keyframe(0f, 0f), new Keyframe(0.25f, 1f), new Keyframe(0.75f, -1f), new Keyframe(1f, 0f) ) ;
 
+    /**
+     * <summary>Explicitly reset static fields to make Unity's Domain Reload optional.</summary>
+     * See https://docs.unity3d.com/2020.1/Documentation/Manual/DomainReloading.html
+     */
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void resetStaticFields(){
+        throwErrors = true;
+        tau = Mathf.PI * 2.0f;
+        PI_DIV2 = Mathf.PI / 2.0f;
+
+        sequences = null;
+
+        tweens = null;
+        tweensFinished = null;
+        tweensFinishedIds = null;
+        tween = null;
+        tweenMaxSearch = -1;
+        maxTweens = 400;
+        maxSequences = 400;
+        frameRendered = -1;
+        _tweenEmpty = null;
+        dtEstimated = -1f;
+        dtManual = 0;
+#if UNITY_3_5 || UNITY_4_0 || UNITY_4_0_1 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_5
+        float previousRealTime = 0;
+#endif
+        dtActual = 0;
+        global_counter = 0;
+        i = 0;
+        j = 0;
+        finishedCnt = 0;
+        punch = new AnimationCurve(new Keyframe(0.0f, 0.0f), new Keyframe(0.112586f, 0.9976035f), new Keyframe(0.3120486f, -0.1720615f), new Keyframe(0.4316337f, 0.07030682f), new Keyframe(0.5524869f, -0.03141804f), new Keyframe(0.6549395f, 0.003909959f), new Keyframe(0.770987f, -0.009817753f), new Keyframe(0.8838775f, 0.001939224f), new Keyframe(1.0f, 0.0f));
+        shake = new AnimationCurve(new Keyframe(0f, 0f), new Keyframe(0.25f, 1f), new Keyframe(0.75f, -1f), new Keyframe(1f, 0f));
+    }
+    
     public static void init(){
         init(maxTweens);
     }


### PR DESCRIPTION
Beeing able to disable Domain Reload is a great performance improvement during development.
For this to work, static fields have to be reset manually.
See also https://docs.unity3d.com/2020.1/Documentation/Manual/DomainReloading.html

The option to disable Domain Reload is available since Unity 2019.3 (I think)